### PR TITLE
Fix(db): Use index for similar songs query

### DIFF
--- a/pkg/db/similar.go
+++ b/pkg/db/similar.go
@@ -66,7 +66,7 @@ func FindSimilarSongs(db *sql.DB, songIDToExclude int, queryEmbedding []float64,
 		JOIN songs s ON se.song_id = s.id
 		LEFT JOIN genres g ON s.genre_id = g.id
 		WHERE se.song_id != $2
-		ORDER BY similarity DESC
+		ORDER BY se.embedding <=> $1
 		LIMIT $3
 	`
 


### PR DESCRIPTION
The query to find similar songs was ordering by the `similarity` alias. This is not guaranteed to use the index on the `embedding` column.

This commit changes the `ORDER BY` clause to order by the L2 distance directly, ensuring the `vchordrq` index is used for the query, which will significantly improve performance.

The `similarity` score returned by the API remains `1 - distance`.